### PR TITLE
Adds body logging to the API

### DIFF
--- a/utils/upload_gcs.py
+++ b/utils/upload_gcs.py
@@ -45,9 +45,7 @@ class GCSTransfer:
 
         blob.upload_from_filename(source_path)
 
-        print('File {} uploaded to {}.'.format(
-            source_path,
-            destination_blob_name))
+        logging.info("File %s uploaded to %s", source_path, destination_blob_name)
 
     def local_transfer(self, source_file_name, source_content):
         """Transfer the attachment file to the bucket."""


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1099

In addition to updating the logging logic to log the email bodies if available, we also updated the code a bit to fix a couple of small issues:

* It now uses logging formatting instead of concatenation.
* If a mail didn't have any attachments, the handler failed, which caused the GAE to retry the email at a later time. We now just skip emails without attachments
* There was a print statement instead of a logging one, which caused a warning on the request logs.